### PR TITLE
IF check is wrong

### DIFF
--- a/OpenLR/LocationExtensions.cs
+++ b/OpenLR/LocationExtensions.cs
@@ -705,7 +705,7 @@ namespace OpenLR
                 }
 
                 if (!lowest.HasValue ||
-                    frc < lowest)
+                    frc > lowest)
                 {
                     lowest = frc;
                 }


### PR DESCRIPTION
lowest should be overwritten if frc on the edge is lower (i.e. has a higher numeric value as road class).
FRC has an inverted scale, so the highest value (FRC7) is the lowest functional road class.