### PR TITLE
Fix decoding of PointAlongLine messages with no positive offset byte

### DIFF
--- a/src/OpenLR/Codecs/Binary/Codecs/PointAlongLineLocationCodec.cs
+++ b/src/OpenLR/Codecs/Binary/Codecs/PointAlongLineLocationCodec.cs
@@ -57,7 +57,7 @@ namespace OpenLR.Codecs.Binary.Decoders
             pointAlongLine.First = first;
             pointAlongLine.Orientation = OrientationConverter.Decode(data, 7, 0);
             pointAlongLine.SideOfRoad = SideOfRoadConverter.Decode(data, 14, 0);
-            pointAlongLine.PositiveOffsetPercentage = OffsetConvertor.Decode(data, 16);
+            pointAlongLine.PositiveOffsetPercentage = data.Length > 16 ? OffsetConvertor.Decode(data, 16) : null;
             pointAlongLine.Last = last;
 
             return pointAlongLine;

--- a/test/OpenLR.Test/Binary/PointAlongLineLocationTests.cs
+++ b/test/OpenLR.Test/Binary/PointAlongLineLocationTests.cs
@@ -6,6 +6,8 @@ using System;
 
 namespace OpenLR.Test.Binary
 {
+    using NuGet.Frameworks;
+
     /// <summary>
     /// Contains tests for decoding/encoding a point along location to/from OpenLR binary representation.
     /// </summary>
@@ -52,6 +54,19 @@ namespace OpenLR.Test.Binary
             Assert.AreEqual(Orientation.NoOrientation, pointAlongLineLocation.Orientation);
             Assert.AreEqual(SideOfRoad.Left, pointAlongLineLocation.SideOfRoad);
             Assert.AreEqual(30.19, pointAlongLineLocation.PositiveOffsetPercentage, 0.5); // binary encode loses accuracy.
+        }
+        
+        /// <summary>
+        /// Decode a message with only 16 bytes, i.e. no positive offset byte
+        /// </summary>
+        [Test]
+        public void DecodeBase64WithNoOffset()
+        {
+            // Message with 16 bytes.
+            var stringData = Convert.FromBase64String("Kwhv2ikWNjPZAP/XAAUzCA==");
+            
+            Assert.IsTrue(PointAlongLineLocationCodec.CanDecode(stringData));
+            Assert.DoesNotThrow(() => PointAlongLineLocationCodec.Decode(stringData));
         }
 
         /// <summary>


### PR DESCRIPTION
Check length of message and skip decoding of positive offset if message is less that 17 bytes long.