### PR TITLE
Fix PointAlongLine offset encoding

### DIFF
--- a/src/OpenLR/Codecs/Binary/Codecs/PointAlongLineLocationCodec.cs
+++ b/src/OpenLR/Codecs/Binary/Codecs/PointAlongLineLocationCodec.cs
@@ -113,6 +113,7 @@ namespace OpenLR.Codecs.Binary.Decoders
             SideOfRoadConverter.Encode(location.SideOfRoad.Value, data, 14, 0);
             if (location.PositiveOffsetPercentage.HasValue)
             { // positive offset percentage is present.
+                OffsetConvertor.EncodeFlag(true, data, 15, 1);
                 OffsetConvertor.Encode(location.PositiveOffsetPercentage.Value, data, 16);
             }
 


### PR DESCRIPTION
This fixes the encoding of positive offsets for PointAlongLine locations.

Previously the flag bit wasn't set by the encoder meaning that references encoded this way could be have their offsets ignored when decoded elsewhere, if the offset flags were checked.

Related to (but does not solve) #91.